### PR TITLE
Update metadata.json to use puppet/wget instead of deprecated maestrodev/wget

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -49,8 +49,8 @@
   ],
   "dependencies": [
     {
-      "name":"maestrodev/wget",
-      "version_requirement": "1.7.3"
+      "name":"puppet/wget",
+      "version_requirement": "2.0.1"
     },
     {
       "name":"puppetlabs/apt",


### PR DESCRIPTION
As maestrodev/wget is deprecated, it is now not possible to pull from forge.puppet.com.

I've forked and validated that the puppet/wget module behaves as expected.

